### PR TITLE
updates for sellect-trade_gecko

### DIFF
--- a/lib/gecko/record/base_adapter.rb
+++ b/lib/gecko/record/base_adapter.rb
@@ -341,7 +341,7 @@ module Gecko
       #
       # @api private
       def create_record(record, opts = {})
-        response = request(:post, plural_path, {
+        response = @last_response = request(:post, plural_path, {
           body: record.as_json,
           raise_errors: false
         }.merge(headers: headers_from_opts(opts)))
@@ -354,7 +354,7 @@ module Gecko
       #
       # @api private
       def update_record(record, opts = {})
-        response = request(:put, plural_path + "/" + record.id.to_s, {
+        response = @last_response = request(:put, plural_path + "/" + record.id.to_s, {
           body: record.as_json,
           raise_errors: false
         }.merge(headers: headers_from_opts(opts)))

--- a/lib/gecko/record/fulfillment_return.rb
+++ b/lib/gecko/record/fulfillment_return.rb
@@ -3,7 +3,8 @@ require 'gecko/record/base'
 module Gecko
   module Record
     class FulfillmentReturn < Base
-      has_many :fulfillment_return_line_items
+      attribute :fulfillment_return_line_items, Array[Hash]
+
       belongs_to :order
       belongs_to :location
 

--- a/lib/gecko/record/image.rb
+++ b/lib/gecko/record/image.rb
@@ -5,8 +5,9 @@ module Gecko
     class Image < Base
       AVAILABLE_SIZES = [:full, :thumbnail]
 
-      belongs_to :variant
+      belongs_to :product
       belongs_to :uploader, class_name: "User",   readonly: true
+      attribute :variant_ids,      Array[Integer]
       attribute :name,             String
       attribute :url,              String
       attribute :position,         Integer,       readonly: true

--- a/lib/gecko/record/order.rb
+++ b/lib/gecko/record/order.rb
@@ -5,7 +5,10 @@ module Gecko
     class Order < Base
       has_many :fulfillments
       has_many :invoices
-      has_many :order_line_items
+      # has_many :order_line_items
+
+      attribute :order_line_items,      Array[Hash]
+      attribute :order_line_item_ids,   Array[Integer]
 
       belongs_to :company
       belongs_to :contact


### PR DESCRIPTION
- last response was only being stored for `finder` methods
  - now stores `last_response` on `update` and `create`
- `has_many` was causing nested resources (i.e. order > line_items) to no build correct requests
  - change `has_many` to `array` `attribute`